### PR TITLE
Patch spec to allow access to labels for tests

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,5 @@
 approvers:
+  - bertinatto
   - bparees
   - soltysh
+  - stbenjam

--- a/internal/spec_patch.go
+++ b/internal/spec_patch.go
@@ -11,3 +11,12 @@ func (s Spec) CodeLocations() []types.CodeLocation {
 func (s Spec) AppendText(text string) {
 	s.Nodes[len(s.Nodes)-1].Text += text
 }
+
+func (s Spec) Labels() []string {
+	var labels []string
+	for _, n := range s.Nodes {
+		labels = append(labels, n.Labels...)
+	}
+
+	return labels
+}

--- a/types/types_patch.go
+++ b/types/types_patch.go
@@ -4,4 +4,5 @@ type TestSpec interface {
 	CodeLocations() []CodeLocation
 	Text() string
 	AppendText(text string)
+	Labels() []string
 }


### PR DESCRIPTION
This lets us access the labels for a test, a potential alternative approach to annotations for deciding where a test runs.

This also adds me to OWNERS.