### PR TITLE
Expose NewWriter from internal for openshift-tests-extension

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,4 @@
+reviewers:
 approvers:
   - bertinatto
   - bparees

--- a/core_dsl_patch.go
+++ b/core_dsl_patch.go
@@ -1,6 +1,8 @@
 package ginkgo
 
 import (
+	"io"
+
 	"github.com/onsi/ginkgo/v2/internal"
 	"github.com/onsi/ginkgo/v2/internal/global"
 	"github.com/onsi/ginkgo/v2/types"
@@ -16,6 +18,10 @@ func GetSuite() *internal.Suite {
 
 func GetFailer() *internal.Failer {
 	return global.Failer
+}
+
+func NewWriter(w io.Writer) *internal.Writer {
+	return internal.NewWriter(w)
 }
 
 func GetWriter() *internal.Writer {


### PR DESCRIPTION
Ginkgo's output writer hardcodes output to always go to os.Stdout, this exposes the NewWriter function so openshift-tests-extension can use it.

This gives us more control over how we handle output from ginkgo, including writing it to `stderr` instead of `stdout`, or writing it to `io.Discard`, while maintaing the bytes buffer for returning output to OTE.