### PR TITLE
Carry patches to allow openshift-tests wrapping of ginkgo v2

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,4 @@
+reviewers:
+approvers:
+  - bertinatto
+  - stbenjam

--- a/core_dsl_patch.go
+++ b/core_dsl_patch.go
@@ -1,0 +1,33 @@
+package ginkgo
+
+import (
+	"io"
+
+	"github.com/onsi/ginkgo/v2/internal"
+	"github.com/onsi/ginkgo/v2/internal/global"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func AppendSpecText(test *internal.Spec, text string) {
+	test.AppendText(text)
+}
+
+func GetSuite() *internal.Suite {
+	return global.Suite
+}
+
+func GetFailer() *internal.Failer {
+	return global.Failer
+}
+
+func NewWriter(w io.Writer) *internal.Writer {
+	return internal.NewWriter(w)
+}
+
+func GetWriter() *internal.Writer {
+	return GinkgoWriter.(*internal.Writer)
+}
+
+func SetReporterConfig(r types.ReporterConfig) {
+	reporterConfig = r
+}

--- a/internal/spec_patch.go
+++ b/internal/spec_patch.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+func (s Spec) CodeLocations() []types.CodeLocation {
+	return s.Nodes.CodeLocations()
+}
+
+func (s Spec) AppendText(text string) {
+	s.Nodes[len(s.Nodes)-1].Text += text
+}
+
+func (s Spec) Labels() []string {
+	var labels []string
+	for _, n := range s.Nodes {
+		labels = append(labels, n.Labels...)
+	}
+
+	return labels
+}

--- a/internal/suite.go
+++ b/internal/suite.go
@@ -68,6 +68,8 @@ type Suite struct {
 	selectiveLock *sync.Mutex
 
 	client parallel_support.Client
+
+	annotateFn AnnotateFunc
 }
 
 func NewSuite() *Suite {
@@ -114,6 +116,11 @@ func (suite *Suite) Run(description string, suiteLabels Labels, suiteSemVerConst
 	}
 	ApplyNestedFocusPolicyToTree(suite.tree)
 	specs := GenerateSpecsFromTreeRoot(suite.tree)
+	if suite.annotateFn != nil {
+		for _, spec := range specs {
+			suite.annotateFn(spec.Text(), spec)
+		}
+	}
 	specs, hasProgrammaticFocus := ApplyFocusToSpecs(specs, description, suiteLabels, suiteSemVerConstraints, suiteConfig)
 	specs = ComputeAroundNodes(specs)
 

--- a/internal/suite_patch.go
+++ b/internal/suite_patch.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"time"
+
+	"github.com/onsi/ginkgo/v2/internal/interrupt_handler"
+	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+type AnnotateFunc func(testName string, test types.TestSpec)
+
+func (suite *Suite) SetAnnotateFn(fn AnnotateFunc) {
+	suite.annotateFn = fn
+}
+
+func (suite *Suite) GetReport() types.Report {
+	return suite.report
+}
+
+func (suite *Suite) WalkTests(fn AnnotateFunc) {
+	if suite.phase != PhaseBuildTree {
+		panic("cannot run before building the tree = call suite.BuildTree() first")
+	}
+	ApplyNestedFocusPolicyToTree(suite.tree)
+	specs := GenerateSpecsFromTreeRoot(suite.tree)
+	for _, spec := range specs {
+		fn(spec.Text(), spec)
+	}
+}
+
+func (suite *Suite) InPhaseBuildTree() bool {
+	return suite.phase == PhaseBuildTree
+}
+
+func (suite *Suite) ClearBeforeAndAfterSuiteNodes() {
+	// Don't build the tree multiple times, it results in multiple initing of tests
+	if !suite.InPhaseBuildTree() {
+		suite.BuildTree()
+	}
+	newNodes := Nodes{}
+	for _, node := range suite.suiteNodes {
+		if node.NodeType == types.NodeTypeBeforeSuite || node.NodeType == types.NodeTypeAfterSuite || node.NodeType == types.NodeTypeSynchronizedBeforeSuite || node.NodeType == types.NodeTypeSynchronizedAfterSuite {
+			continue
+		}
+		newNodes = append(newNodes, node)
+	}
+	suite.suiteNodes = newNodes
+}
+
+func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suiteDescription, suitePath string, failer *Failer, writer WriterInterface, suiteConfig types.SuiteConfig, reporterConfig types.ReporterConfig) (bool, bool) {
+	if suite.phase != PhaseBuildTree {
+		panic("cannot run before building the tree = call suite.BuildTree() first")
+	}
+
+	suite.phase = PhaseRun
+	suite.client = nil
+	suite.failer = failer
+	suite.reporter = reporters.NewDefaultReporter(reporterConfig, writer)
+	suite.writer = writer
+	suite.outputInterceptor = NoopOutputInterceptor{}
+	if suite.config.Timeout > 0 {
+		suite.deadline = time.Now().Add(suiteConfig.Timeout)
+	}
+	suite.interruptHandler = interrupt_handler.NewInterruptHandler(nil)
+	suite.config = suiteConfig
+
+	success := suite.runSpecs(suiteDescription, suiteLabels, SemVerConstraints{}, suitePath, false, []Spec{spec.(Spec)})
+
+	return success, false
+}

--- a/types/types_patch.go
+++ b/types/types_patch.go
@@ -1,0 +1,8 @@
+package types
+
+type TestSpec interface {
+	CodeLocations() []CodeLocation
+	Text() string
+	AppendText(text string)
+	Labels() []string
+}


### PR DESCRIPTION
Update suite.config.Timeout configuration logic for ginkgo v2.4 bump

Make sure ginkgo.By is printed

Merge pull request #15 from stbenjam/labels

Patch spec to allow access to labels for tests

Merge pull request #16 from stbenjam/writer

Expose NewWriter from internal for openshift-tests-extension

Remove bparees and soltysh from owners