### PR TITLE
TRT-2539: Capture stdout/stderr in RunSpec while forwarding output in real-time

### DIFF
--- a/internal/output_interceptor_wasm.go
+++ b/internal/output_interceptor_wasm.go
@@ -2,6 +2,13 @@
 
 package internal
 
+import "os"
+
+// dupStdout returns nil on WASM since output interception is not supported.
+func dupStdout() *os.File {
+	return nil
+}
+
 func NewOutputInterceptor() OutputInterceptor {
 	return &NoopOutputInterceptor{}
 }

--- a/internal/output_interceptor_win.go
+++ b/internal/output_interceptor_win.go
@@ -2,6 +2,15 @@
 
 package internal
 
+import "os"
+
+// dupStdout returns the current os.Stdout. On Windows, the output interceptor
+// uses osGlobalReassigning which only changes the Go variable, so capturing
+// the current os.Stdout before interception starts is sufficient.
+func dupStdout() *os.File {
+	return os.Stdout
+}
+
 func NewOutputInterceptor() OutputInterceptor {
 	return NewOSGlobalReassigningOutputInterceptor()
 }

--- a/internal/suite_patch.go
+++ b/internal/suite_patch.go
@@ -1,12 +1,79 @@
 package internal
 
 import (
+	"io"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo/v2/internal/interrupt_handler"
 	"github.com/onsi/ginkgo/v2/reporters"
 	"github.com/onsi/ginkgo/v2/types"
 )
+
+// ForwardingOutputInterceptor wraps a real OutputInterceptor but forwards
+// captured output to stdout in real-time. This allows stdout/stderr to be
+// captured in test results while still showing output during test execution.
+type ForwardingOutputInterceptor struct {
+	interceptor OutputInterceptor
+	stdoutClone *os.File
+}
+
+// NewForwardingOutputInterceptor creates an output interceptor that captures
+// stdout/stderr while also forwarding it to a clone of stdout in real-time.
+// The stdout clone is created using dupStdout() (platform-specific) before
+// the interceptor redirects output, ensuring output is always forwarded to
+// the original terminal.
+func NewForwardingOutputInterceptor() *ForwardingOutputInterceptor {
+	// Create a clone of stdout BEFORE the interceptor can redirect it.
+	// This ensures we always have a handle to the original terminal for
+	// forwarding output. The dupStdout() function is platform-specific.
+	stdoutClone := dupStdout()
+	if stdoutClone == nil {
+		// If we can't dup stdout, fall back to NoopOutputInterceptor behavior
+		return &ForwardingOutputInterceptor{
+			interceptor: NoopOutputInterceptor{},
+			stdoutClone: nil,
+		}
+	}
+
+	return &ForwardingOutputInterceptor{
+		interceptor: NewOutputInterceptor(),
+		stdoutClone: stdoutClone,
+	}
+}
+
+func (f *ForwardingOutputInterceptor) StartInterceptingOutput() {
+	if f.stdoutClone != nil {
+		f.interceptor.StartInterceptingOutputAndForwardTo(f.stdoutClone)
+	} else {
+		f.interceptor.StartInterceptingOutput()
+	}
+}
+
+func (f *ForwardingOutputInterceptor) StartInterceptingOutputAndForwardTo(w io.Writer) {
+	f.interceptor.StartInterceptingOutputAndForwardTo(w)
+}
+
+func (f *ForwardingOutputInterceptor) StopInterceptingAndReturnOutput() string {
+	return f.interceptor.StopInterceptingAndReturnOutput()
+}
+
+func (f *ForwardingOutputInterceptor) PauseIntercepting() {
+	f.interceptor.PauseIntercepting()
+}
+
+func (f *ForwardingOutputInterceptor) ResumeIntercepting() {
+	f.interceptor.ResumeIntercepting()
+}
+
+func (f *ForwardingOutputInterceptor) Shutdown() {
+	f.interceptor.Shutdown()
+	if f.stdoutClone != nil {
+		f.stdoutClone.Close()
+		f.stdoutClone = nil
+	}
+}
 
 type AnnotateFunc func(testName string, test types.TestSpec)
 
@@ -58,7 +125,11 @@ func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suiteDescri
 	suite.failer = failer
 	suite.reporter = reporters.NewDefaultReporter(reporterConfig, writer)
 	suite.writer = writer
-	suite.outputInterceptor = NoopOutputInterceptor{}
+	if strings.ToLower(suiteConfig.OutputInterceptorMode) == "none" {
+		suite.outputInterceptor = NoopOutputInterceptor{}
+	} else {
+		suite.outputInterceptor = NewForwardingOutputInterceptor()
+	}
 	if suite.config.Timeout > 0 {
 		suite.deadline = time.Now().Add(suiteConfig.Timeout)
 	}


### PR DESCRIPTION
Previously, RunSpec used NoopOutputInterceptor which meant stdout/stderr output from tests was not captured in CapturedStdOutErr. Only output written to GinkgoWriter was available in test results.

This adds a ForwardingOutputInterceptor that wraps the real output interceptor but overrides StartInterceptingOutput to forward captured output to a clone of stdout in real-time. This means:

- CapturedStdOutErr now contains stdout/stderr output from tests
- Output is still visible in the terminal during test execution
- The existing OutputInterceptorMode field is respected: setting it to "none" disables capture and uses NoopOutputInterceptor (old behavior)

The stdout clone is created via a platform-specific dupStdout() function using dup(2) on Unix, os.Stdout on Windows, and nil on WASM.

---

Note: tested here -> https://github.com/openshift/origin/pull/30769

Example file: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/30769/pull-ci-openshift-origin-main-e2e-gcp-ovn/2021058466696663040/artifacts/e2e-gcp-ovn/openshift-e2e-test/artifacts/junit/extension_test_result_e2e__20260210-041807-everything.html

The "everything" artifact is 50MB, which is large, you need to wait for it to load.  Look at some "flaky" test outputs to se we now collect everything.

"Summary" which is shown in spyglass isn't that bad -> https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/30769/pull-ci-openshift-origin-main-e2e-gcp-ovn/2021058466696663040/artifacts/e2e-gcp-ovn/openshift-e2e-test/artifacts/junit/extension_test_result_e2e__20260210-041807-summary.html

