### PR TITLE
Adapt ginkgo carries to v2.28.1 Suite.Run() function signature changes

### DIFF
--- a/internal/suite_patch.go
+++ b/internal/suite_patch.go
@@ -136,7 +136,7 @@ func (suite *Suite) RunSpec(spec types.TestSpec, suiteLabels Labels, suiteDescri
 	suite.interruptHandler = interrupt_handler.NewInterruptHandler(nil)
 	suite.config = suiteConfig
 
-	success := suite.runSpecs(suiteDescription, suiteLabels, SemVerConstraints{}, suitePath, false, []Spec{spec.(Spec)})
+	success := suite.runSpecs(suiteDescription, suiteLabels, SemVerConstraints{}, ComponentSemVerConstraints{}, suitePath, false, []Spec{spec.(Spec)})
 
 	return success, false
 }


### PR DESCRIPTION
Suite.Run() function signature was changed in v2.28.1 upstream as a part of https://github.com/onsi/ginkgo/pull/1635. This function signature change update was missed in an openshift-specific file `internal/suite_patch.go`